### PR TITLE
remove old seedgen endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -69,15 +69,6 @@ export async function build() {
     }
   })
 
-  app.get('/seedgen', async (req, res, next) => {
-    try {
-      const newSeed = await generateSeed({})
-      res.json(newSeed)
-    } catch (e) {
-      next(e)
-    }
-  })
-
   app.post('/did-web-generator', async (req, res, next) => {
     try {
       const { url } = req.body

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -233,20 +233,6 @@ describe('api', () => {
     })
   })
 
-  describe('/did-key-generator', () => {
-    it('returns a new did:key', async () => {
-      await request(app)
-        .get(`/seedgen`)
-        .expect('Content-Type', /json/)
-        .expect((res) => {
-          expect(res.body.seed).to.exist
-          expect(res.body.didDocument.id).to.contain('did:key')
-          expect(res.body.did).to.contain('did:key')
-        })
-        .expect(200)
-    })
-  })
-
   describe('/healthz', () => {
     it('returns 200 when healthy', async () => {
       await request(app)


### PR DESCRIPTION
old seedgen endpoint that generated a did:key seed has been replaced with did-key-generator and did-web-generator endpoints.
Tidying this up as part of adding did-key-generator and did-web-generator endpoints to issuer-coordinator and workflow-coordinator.