### PR TITLE
set vc.issuer appropriately

### DIFF
--- a/src/issue.js
+++ b/src/issue.js
@@ -56,11 +56,11 @@ const issue = async (unsignedVerifiableCredential, instanceId) => {
   return signedVerifiableCredential
 }
 
-const addIssuerId = (vc, issuerId) => {
-  if (vc.issuer && typeof vc.issuer === 'string') {
-    vc.issuer = issuerId
+const addIssuerId = (credential, issuerId) => {
+  if (credential.issuer && typeof credential.issuer === 'string') {
+    credential.issuer = issuerId
   } else {
-    ;(vc.issuer ??= {}).id = issuerId
+    ;(credential.issuer ??= {}).id = issuerId
   }
 }
 

--- a/src/issue.js
+++ b/src/issue.js
@@ -57,10 +57,25 @@ const issue = async (unsignedVerifiableCredential, instanceId) => {
 }
 
 const addIssuerId = (credential, issuerId) => {
-  if (credential.issuer && typeof credential.issuer === 'string') {
+  if (!credential.issuer) {
+    throw new SigningException(
+      420,
+      'An issuer property, either string or object, must be present.'
+    )
+  } else if (Array.isArray(credential.issuer)) {
+    throw new SigningException(
+      420,
+      'An issuer property cannot be an Array, only a string or object.'
+    )
+  } else if (typeof credential.issuer === 'string') {
     credential.issuer = issuerId
+  } else if (typeof credential.issuer === 'object') {
+    credential.issuer.id = issuerId
   } else {
-    ;(credential.issuer ??= {}).id = issuerId
+    throw new SigningException(
+      420,
+      'The issuer property must be either a string or an object.'
+    )
   }
 }
 

--- a/src/issue.js
+++ b/src/issue.js
@@ -44,13 +44,24 @@ const getIssuerInstance = async (instanceId) => {
   return ISSUER_INSTANCES[instanceId]
 }
 
-const issue = async (unsignedVerifiableCredential, issuerId) => {
-  const { issuerInstance, didDocument } = await getIssuerInstance(issuerId)
-  unsignedVerifiableCredential.issuer.id = didDocument.id
-  const signedCredential = await issuerInstance.issueCredential({
+const issue = async (unsignedVerifiableCredential, instanceId) => {
+  const {
+    issuerInstance,
+    didDocument: { id: issuerId }
+  } = await getIssuerInstance(instanceId)
+  addIssuerId(unsignedVerifiableCredential, issuerId)
+  const signedVerifiableCredential = await issuerInstance.issueCredential({
     credential: unsignedVerifiableCredential
   })
-  return signedCredential
+  return signedVerifiableCredential
+}
+
+const addIssuerId = (vc, issuerId) => {
+  if (vc.issuer && typeof vc.issuer === 'string') {
+    vc.issuer = issuerId
+  } else {
+    ;(vc.issuer ??= {}).id = issuerId
+  }
 }
 
 const buildIssuerInstance = async (seed, method, url) => {


### PR DESCRIPTION
If the incoming VC (to be signed) already has the top level issuer property set as a string value, then set that value to the did used to sign the VC. Set the value even if the existing value was different (i.e., overwrite the value).

If the incoming VC has a top level issuer property set to an object then set the 'id' property on that object with the did used to the sign the VC. Again, overwrite the id even if it is different from the signing did.

If the incoming VC has no issuer property or no value set for the issuer property then set the issuer property to be an object with an id property whose value is the signing DID.