### PR TITLE
update security-document-loader and vc libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint .  --ext .js",
     "lint-fix": "eslint --fix .  --ext .js",
     "test-no-coverage": "NODE_OPTIONS=--experimental-vm-modules npx mocha --timeout 10000 -r dotenv/config dotenv_config_path=src/test-fixtures/.env.testing src/*.test.js",
-    
     "test": "NODE_OPTIONS=--experimental-vm-modules npx c8 mocha --timeout 10000 -r dotenv/config dotenv_config_path=src/test-fixtures/.env.testing src/*.test.js",
     "coveralls": "npm run test; c8 report --reporter=text-lcov | coveralls",
     "prepare": "test -d node_modules/husky && husky install || echo \"husky is not installed\"",
@@ -23,8 +22,8 @@
     "@digitalbazaar/ed25519-signature-2020": "^5.4.0",
     "@digitalbazaar/ed25519-verification-key-2020": "^4.1.0",
     "@digitalbazaar/eddsa-rdfc-2022-cryptosuite": "^1.2.0",
-    "@digitalbazaar/vc": "^7.0.0",
-    "@digitalcredentials/security-document-loader": "^6.0.0",
+    "@digitalbazaar/vc": "^7.2.0",
+    "@digitalcredentials/security-document-loader": "^8.0.0",
     "@interop/did-web-resolver": "^5.0.0",
     "axios": "^1.6.8",
     "base32-encode": "^2.0.0",


### PR DESCRIPTION
update to latest security-document-loader and vc libs, in particular to get the new VC DM 2.0 and OBv3.0.3 contexts